### PR TITLE
feat: Implement permission system based on user level

### DIFF
--- a/login.cpp
+++ b/login.cpp
@@ -71,8 +71,7 @@ void Login::on_BtnIngresar_clicked()
           qm->exec();
     }else{
         this->close();
-        MainWindow *mw = new MainWindow();
-        //asignarPermisos(  );
+        MainWindow *mw = new MainWindow(tra);
         mw->show();
     }
 
@@ -81,6 +80,7 @@ ListaTrabajadores *Login::getLTra() const
 {
     return lTra;
 }
+
 
 void Login::setLTra(ListaTrabajadores *value)
 {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -11,7 +11,7 @@
 #include "reservaequipo.h"
 #include "registrartrabajador.h"
 
-MainWindow::MainWindow(QWidget *parent) :
+MainWindow::MainWindow(Trabajador *tra, QWidget *parent) :
     QMainWindow(parent),
     ui(new Ui::MainWindow)
 {
@@ -21,11 +21,29 @@ MainWindow::MainWindow(QWidget *parent) :
                         "background-image:url(:/Recursos/Fondo.jpg); "
                         "background-position:center;");
     this->showMaximized(); // mostrar ventana maximizada
+    asignarPermisos(tra);
 }
 
 MainWindow::~MainWindow()
 {
     delete ui;
+}
+
+void MainWindow::asignarPermisos(Trabajador *tra)
+{
+    switch (tra->getNivel()) {
+    case 1:
+        // Admin, all access
+        break;
+    case 2:
+        // Encargado, limited access
+        ui->actionRegistrar_Trabajador->setEnabled(false);
+        ui->actionRegistrar_facultades->setEnabled(false);
+        ui->actionRegistrar_laboratorio->setEnabled(false);
+        ui->actionRegistrar_Docente->setEnabled(false);
+        ui->actionRegistrar_Estudiante->setEnabled(false);
+        break;
+    }
 }
 
 void MainWindow::on_actionRegistrar_facultades_triggered()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -1,6 +1,7 @@
 #ifndef MAINWINDOW_H
 #define MAINWINDOW_H
 #include "universidad.h"
+#include "trabajador.h"
 
 #include <QMainWindow>
 
@@ -13,8 +14,9 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
 public:
-    explicit MainWindow(QWidget *parent = 0);
+    explicit MainWindow(Trabajador *tra, QWidget *parent = 0);
     ~MainWindow();
+    void asignarPermisos(Trabajador *tra);
 
 private slots:
     void on_actionRegistrar_facultades_triggered();


### PR DESCRIPTION
This commit introduces a permission system based on the `nivel` attribute of a user.

- The `asignarPermisos` function has been moved from `login.cpp` to `mainwindow.cpp`.
- The `MainWindow` now accepts a `Trabajador` object in its constructor and calls `asignarPermisos` to set the permissions for the logged-in user.
- Users with `nivel` 2 now have restricted access to the application, with several menu items disabled.